### PR TITLE
Fix: 1. [CommentInput] readonly prop 추가 2. [게시물모달] safari, chrome 모바일 환경에서 하단 url입력창 제거

### DIFF
--- a/src/components/CommentInput/CommentInput.component.tsx
+++ b/src/components/CommentInput/CommentInput.component.tsx
@@ -13,6 +13,10 @@ interface ICommentInputProps {
    */
   value?: string;
   /**
+   * 컴포넌트 readonly 처리
+   */
+  readOnly?: boolean;
+  /**
    * CommentInput을 클릭할 때 실행하는 함수
    */
   onClick?: () => void;
@@ -33,6 +37,7 @@ export default function CommentInput(props: ICommentInputProps) {
   // props
   const {
     value,
+    readOnly = false,
     onClick,
     onChange,
     onButtonClick,
@@ -46,11 +51,18 @@ export default function CommentInput(props: ICommentInputProps) {
     >
       <button
         className="flex h-full w-[50px] items-center justify-center"
-        onClick={() => alert("기능 제작중입니다")}
+        onClick={() => {
+          if (readOnly) {
+            onClick && onClick();
+            return;
+          }
+          alert("기능 제작중입니다");
+        }}
       >
         <BiSmile className="h-[25px] w-[25px]" />
       </button>
       <input
+        readOnly={readOnly}
         placeholder="댓글을 추가하세요."
         className="w-full px-2"
         value={value}
@@ -60,7 +72,13 @@ export default function CommentInput(props: ICommentInputProps) {
       />
       <ColorButton
         text="보내기"
-        onClick={onButtonClick}
+        onClick={(e) => {
+          if (readOnly) {
+            onClick && onClick();
+            return;
+          }
+          onButtonClick && onButtonClick();
+        }}
         className="h-[40px] w-[80px] bg-blue-500"
       >
         {buttonText}

--- a/src/components/Post/Post.component.tsx
+++ b/src/components/Post/Post.component.tsx
@@ -137,7 +137,7 @@ export default function Post(props: IPostProps) {
             <span className="text-gray-400">{dayjs(createDate).fromNow()}</span>
           </div>
         </section>
-        <CommentInput onClick={openModal} />
+        <CommentInput readOnly onClick={openModal} />
       </section>
 
       {isOpen && (

--- a/src/components/PostModal/PostModal.component.tsx
+++ b/src/components/PostModal/PostModal.component.tsx
@@ -157,7 +157,7 @@ export default function PostModal(props: IPostModalProps) {
 
   return (
     <Modal open={open} onClose={onClose}>
-      <section className="flex h-[calc(100vh-40px)] w-screen min-w-[320px] max-w-[500px] flex-col overflow-y-auto overscroll-none bg-white lg:h-[500px] lg:w-[900px] lg:min-w-0 lg:max-w-none lg:flex-row lg:pb-0">
+      <section className="flex h-[calc(100dvh-40px)] w-screen min-w-[320px] max-w-[500px] flex-col overflow-y-auto overscroll-none bg-white lg:h-[500px] lg:w-[900px] lg:min-w-0 lg:max-w-none lg:flex-row lg:pb-0">
         <div className="relative aspect-square max-h-[220px] w-full bg-black lg:h-full lg:max-h-none lg:w-[60%]">
           <Image
             src={post?.image_url || "/"}


### PR DESCRIPTION
1. [Fix:[CommentInput] readonly prop 추가 - 클릭 interaction 가능 여부 분리](https://github.com/changmoolee/joseph-instagram/commit/85ddf6cb57f3dcace73a1709d7aaa1de48c17559)
- input이 아닌 버튼 역할만 할수 있도록 수정 (모바일에서 input이 focus 되는 현상)

2. [Fix:[게시물모달] safari, chrome 모바일 환경에서 하단 url입력창 ui로 인해 가려지는 현상 제거 -> 100dvh](https://github.com/changmoolee/joseph-instagram/commit/22e2783a92138c4dd1690ac970ff7b4351acefc6) 
- safari, chrome 모바일 환경에서 하단 url입력창 ui가 input 등 ui를 가려버리는 현상