### PR TITLE
Fix: IOS Safari 이슈 -  크로스사이트(Cross-Site) 쿠키 차단 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_ENV=development next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "NODE_ENV=production next start",
     "lint": "next lint"
   },
   "dependencies": {

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+/**
+ * IOS Safari는 크로스사이트 요청에 대해 쿠키를 매우 엄격하게 제한하므로
+ * API Routes를 활용하여 로그인 쿠키를 설정
+ * 브라우저 -> Next.js API Routes -> Nest.js -> Next.js API Routes -> 브라우저
+ */
+export async function POST(req: NextRequest) {
+  try {
+    /** 요청 body값 */
+    const body = await req.json();
+
+    /**
+     * 로그인 API
+     * 받은 POST 요청을 Nest.js 서버에 그대로 요청
+     */
+    const signinResponse = await fetch(
+      `${process.env.NEXT_PUBLIC_NESTJS_SERVER}/auth/signin`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        credentials: "include",
+      }
+    );
+
+    const signinData = await signinResponse.json();
+
+    /** 토큰 */
+    const tokenValue = signinData.data.token;
+
+    if (!tokenValue) {
+      throw new Error("로그인을 실패하였습니다. (쿠키값 없음)");
+    }
+
+    cookies().set({
+      name: "token",
+      value: tokenValue,
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: process.env.NODE_ENV === "production" ? "none" : "strict",
+      maxAge: 2 * 60 * 60 * 1000, // 2시간 후 만료
+    });
+
+    return NextResponse.json(signinData);
+  } catch (error: any) {
+    console.error(error);
+    return NextResponse.json({
+      data: null,
+      result: "failure",
+      message: error.response?.data?.message || error.message,
+    });
+  }
+}

--- a/src/utils/services/user.ts
+++ b/src/utils/services/user.ts
@@ -48,7 +48,7 @@ export const signIn = async (
     const { email, password } = data;
 
     const response: ICommonResponse<IUser> = await apiClient.post(
-      `${process.env.NEXT_PUBLIC_NESTJS_SERVER}/auth/signin`,
+      `/api/login`,
       {
         email,
         password,


### PR DESCRIPTION
- 이슈 : 로그인 api 호출시, IOS Safari 환경에서 쿠키가 저장되지 않아 로그인한 회원이 정상적으로 서비스를 이용할 수 없음. (이외의 환경에서는 가능)
- 원인 : IOS Safari 환경은 도메인이 같을 경우 쿠키 설정에 제한이 없지만, 크로스 사이트일 경우 쿠키 설정을 엄격하게 제한함
- 해결 : 로그인 api 요청시, Nextjs API Routes를 경유하여 응답값으로 토큰값을 받고, Nextjs API Routes단에서 직접 쿠키를 설정하도록 함.