### PR TITLE
Refactor:[로그인 인증] 기존 쿠키인증에서 토큰전달 방식으로 변경(iOS Safari 이슈)

### DIFF
--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -7,6 +7,17 @@ const apiClient = axios.create({
 });
 
 // axios 인터셉터 추가
+apiClient.interceptors.request.use((config) => {
+  // localStorage에서 token 추출
+  const token = localStorage.getItem("token");
+
+  // 존재할시 요청 header에 추가
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 apiClient.interceptors.response.use(
   (response) => {
     return response;

--- a/src/utils/services/user.ts
+++ b/src/utils/services/user.ts
@@ -37,23 +37,36 @@ export const signUp = async (
   }
 };
 
+interface ISignInResult extends IUser {
+  token: string;
+}
+
 /**
  * 로그인 함수
  */
 export const signIn = async (
-  data: ISignInFormValues
+  props: ISignInFormValues
 ): Promise<ICommonReturn<IUser>> => {
   try {
     // 객체분해할당
-    const { email, password } = data;
+    const { email, password } = props;
 
-    const response: ICommonResponse<IUser> = await apiClient.post(
+    const response: ICommonResponse<ISignInResult> = await apiClient.post(
       `${process.env.NEXT_PUBLIC_NESTJS_SERVER}/auth/signin`,
       {
         email,
         password,
       }
     );
+
+    const signInData = response.data.data;
+
+    if (!signInData) {
+      throw new Error("로그인에 실패하였습니다.(응답값 없음)");
+    }
+
+    // 토큰값을 localStorage에 저장
+    localStorage.setItem("token", signInData.token);
 
     return response.data;
   } catch (error: any) {


### PR DESCRIPTION
- iOS Safari 이슈 : 쿠키가 저장안되는 현상 (크로스 사이트 이슈)
- 해결 : 인증방법을 쿠키인증에서 -> 토큰 전달 방식으로 변경