### PR TITLE
Feat: AuthContext context, ToastContext, AlertModal 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import Header from "@/components/Header/Header.component";
 import "./globals.css";
 import type { Metadata } from "next";
+import ToastProvider from "@/context/ToastContext";
 
 export const metadata: Metadata = {
   title: "joseph-instagram에 오신걸 환영합니다.",
@@ -15,8 +16,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="relative w-full min-w-[320px] pb-[50px] pt-[100px]">
-        <Header />
-        {children}
+        <ToastProvider>
+          <Header />
+          {children}
+        </ToastProvider>
       </body>
     </html>
   );

--- a/src/app/my-page/layout.tsx
+++ b/src/app/my-page/layout.tsx
@@ -1,0 +1,9 @@
+import { AuthProvider } from "@/context/AuthContext";
+
+export default function MypageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <AuthProvider>{children}</AuthProvider>;
+}

--- a/src/app/post/layout.tsx
+++ b/src/app/post/layout.tsx
@@ -1,0 +1,9 @@
+import { AuthProvider } from "@/context/AuthContext";
+
+export default function PostLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <AuthProvider>{children}</AuthProvider>;
+}

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import AlertModal from "@/components/AlertModal/AlertModal.component";
 import ColorButton from "@/components/ColorButton/ColorButton.component";
 import PostModal from "@/components/PostModal/PostModal.component";
 import BigProfileImage from "@/components/ProfileImage/BigProfileImage.component";
@@ -30,7 +31,17 @@ export default function User({ params }: { params: { user_id: string } }) {
   const [clickedId, setClickedId] = React.useState<number>();
 
   // modal 커스텀 훅
-  const { isOpen, openModal, closeModal } = useModal();
+  const {
+    isOpen: isPostOpen,
+    openModal: openPostModal,
+    closeModal: closePostModal,
+  } = useModal();
+
+  const {
+    isOpen: isLoginOpen,
+    openModal: openLoginModal,
+    closeModal: closeLoginModal,
+  } = useModal();
 
   /**
    * 유저 개인의 포스트 데이터 호출
@@ -55,7 +66,7 @@ export default function User({ params }: { params: { user_id: string } }) {
 
   const excuteFollowApi = async (userData: IUserInfo) => {
     if (!userInfo?.id) {
-      alert("로그인이 필요합니다.");
+      openLoginModal();
       return;
     }
 
@@ -107,7 +118,7 @@ export default function User({ params }: { params: { user_id: string } }) {
                         if (isLogin && userData) {
                           excuteFollowApi(userData);
                         } else {
-                          alert("로그인이 필요합니다.");
+                          openLoginModal();
                         }
                       }}
                     />
@@ -207,7 +218,7 @@ export default function User({ params }: { params: { user_id: string } }) {
               >
                 <button
                   onClick={() => {
-                    openModal();
+                    openPostModal();
                     setClickedId(post.id);
                   }}
                 >
@@ -225,12 +236,21 @@ export default function User({ params }: { params: { user_id: string } }) {
         </ul>
 
         {/* 게시물 이미지 클릭시 생성되는 게시물 모달 */}
-        {isOpen && clickedId && (
+        {isPostOpen && clickedId && (
           <PostModal
-            open={isOpen}
-            onClose={closeModal}
+            open={isPostOpen}
+            onClose={closePostModal}
             userInfo={userInfo}
             id={clickedId}
+          />
+        )}
+
+        {isLoginOpen && (
+          <AlertModal
+            message="로그인이 필요합니다."
+            open={isLoginOpen}
+            onClose={closeLoginModal}
+            showCancelButton={true}
           />
         )}
       </div>

--- a/src/components/AlertModal/AlertModal.component.tsx
+++ b/src/components/AlertModal/AlertModal.component.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import React from "react";
+import Modal from "@/components/Modal/Modal.component";
+import { useRouter } from "next/navigation";
+
+interface IAlertModalProps {
+  /**
+   * AlertModal 구현 여부
+   */
+  open: boolean;
+  /**
+   * AlertModal 닫는 함수
+   */
+  onClose: () => void;
+  /**
+   * 메시지 내용
+   */
+  message: string;
+  /**
+   * 취소 버튼 사용 유무
+   */
+  showCancelButton: boolean;
+}
+
+/**
+ * Alert 모달
+ * @description 각종 알림 모달
+ */
+export default function AlertModal(props: IAlertModalProps) {
+  // props
+  const { open, onClose, message, showCancelButton } = props;
+
+  const router = useRouter();
+
+  const redirectToLogin = () => router.push("/login");
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <section className="flex h-screen w-screen items-center justify-center">
+        <div className="flex max-h-[200px] min-h-[150px] w-[90%] max-w-[300px] flex-col justify-between rounded-lg bg-white p-[20px] pt-[30px]">
+          {/* 메시지 */}
+          <span className="text-lg font-bold">{message}</span>
+
+          {/* 버튼 */}
+          <article className="flex gap-2">
+            {showCancelButton && (
+              <button
+                className="flex-1 rounded-md bg-gray-200 p-[5px] text-black"
+                onClick={onClose}
+              >
+                취소
+              </button>
+            )}
+            <button
+              className="flex-1 rounded-md bg-blue-500 p-[5px] text-white"
+              onClick={redirectToLogin}
+            >
+              확인
+            </button>
+          </article>
+        </div>
+      </section>
+    </Modal>
+  );
+}

--- a/src/components/Post/Post.component.tsx
+++ b/src/components/Post/Post.component.tsx
@@ -15,6 +15,7 @@ import { excuteBookmark } from "@/utils/services/bookmark";
 import { useModal } from "@/hooks/components/useModal";
 import { IUser } from "@/typescript/user.interface";
 import { mutate } from "swr";
+import AlertModal from "@/components/AlertModal/AlertModal.component";
 
 // dayjs의 RelativeTime 플러그인 추가
 dayjs.extend(relativeTime);
@@ -49,14 +50,24 @@ export default function Post(props: IPostProps) {
   const getPostsUrlKey = `${process.env.NEXT_PUBLIC_NESTJS_SERVER}/post`;
 
   // modal 커스텀 훅
-  const { isOpen, openModal, closeModal } = useModal();
+  const {
+    isOpen: isPostOpen,
+    openModal: openPostModal,
+    closeModal: closePostModal,
+  } = useModal();
+
+  const {
+    isOpen: isLoginOpen,
+    openModal: openLoginModal,
+    closeModal: closeLoginModal,
+  } = useModal();
 
   /** 유저 개인 프로필 전역 상태 데이터 */
   const userInfo = useLoginStore((state) => state.userInfo);
 
   const excuteLikeApi = async () => {
     if (!userInfo?.id) {
-      alert("로그인이 필요합니다.");
+      openLoginModal();
       return;
     }
 
@@ -74,7 +85,7 @@ export default function Post(props: IPostProps) {
 
   const excuteBookmarkApi = async () => {
     if (!userInfo?.id) {
-      alert("로그인이 필요합니다.");
+      openLoginModal();
       return;
     }
 
@@ -137,15 +148,23 @@ export default function Post(props: IPostProps) {
             <span className="text-gray-400">{dayjs(createDate).fromNow()}</span>
           </div>
         </section>
-        <CommentInput readOnly onClick={openModal} />
+        <CommentInput readOnly onClick={openPostModal} />
       </section>
-
-      {isOpen && (
+      {isPostOpen && (
         <PostModal
-          open={isOpen}
-          onClose={closeModal}
+          open={isPostOpen}
+          onClose={closePostModal}
           userInfo={userInfo}
           id={post_id}
+        />
+      )}
+
+      {isLoginOpen && (
+        <AlertModal
+          message="로그인이 필요합니다."
+          open={isLoginOpen}
+          onClose={closeLoginModal}
+          showCancelButton={true}
         />
       )}
     </div>

--- a/src/components/PostModal/PostModal.component.tsx
+++ b/src/components/PostModal/PostModal.component.tsx
@@ -23,6 +23,7 @@ import Link from "next/link";
 import { deletePost } from "@/utils/services/post";
 import { useRouter } from "next/navigation";
 import { excuteBookmark } from "@/utils/services/bookmark";
+import AlertModal from "@/components/AlertModal/AlertModal.component";
 
 // dayjs의 RelativeTime 플러그인 추가
 dayjs.extend(relativeTime);
@@ -64,7 +65,17 @@ export default function PostModal(props: IPostModalProps) {
   const getCommentsUrlKey = `${process.env.NEXT_PUBLIC_NESTJS_SERVER}/comment/post/${id}`;
 
   // modal 커스텀 훅
-  const { isOpen, openModal, closeModal } = useModal();
+  const {
+    isOpen: isCommentOpen,
+    openModal: openCommentModal,
+    closeModal: closeCommentModal,
+  } = useModal();
+
+  const {
+    isOpen: isLoginOpen,
+    openModal: openLoginModal,
+    closeModal: closeLoginModal,
+  } = useModal();
 
   /** 게시물 조회  */
   const { data: post } = useGetPost(id);
@@ -74,7 +85,7 @@ export default function PostModal(props: IPostModalProps) {
 
   const deletePostApi = async () => {
     if (!userInfo?.id) {
-      alert("로그인이 필요합니다.");
+      openLoginModal();
       return;
     }
 
@@ -100,7 +111,7 @@ export default function PostModal(props: IPostModalProps) {
 
   const makeCommentApi = async () => {
     if (!userInfo?.id) {
-      alert("로그인이 필요합니다.");
+      openLoginModal();
       return;
     }
 
@@ -121,7 +132,7 @@ export default function PostModal(props: IPostModalProps) {
 
   const excuteLikeApi = async () => {
     if (!userInfo?.id) {
-      alert("로그인이 필요합니다.");
+      openLoginModal();
       return;
     }
 
@@ -139,7 +150,7 @@ export default function PostModal(props: IPostModalProps) {
 
   const excuteBookmarkApi = async () => {
     if (!userInfo?.id) {
-      alert("로그인이 필요합니다.");
+      openLoginModal();
       return;
     }
 
@@ -208,7 +219,7 @@ export default function PostModal(props: IPostModalProps) {
             <div className="flex justify-end p-[10px] lg:hidden">
               <button
                 className="text-[14px] text-gray-400 underline"
-                onClick={openModal}
+                onClick={openCommentModal}
               >
                 댓글보기
               </button>
@@ -248,13 +259,22 @@ export default function PostModal(props: IPostModalProps) {
       </section>
 
       {/* 모바일뷰에서 생성되는 댓글모달 */}
-      {isOpen && (
+      {isCommentOpen && (
         <CommentModal
-          open={isOpen}
-          onClose={closeModal}
+          open={isCommentOpen}
+          onClose={closeCommentModal}
           comments={comments || []}
           user_id={userInfo?.id}
           post_id={id}
+        />
+      )}
+      {/* 로그인 검증 모달 */}
+      {isLoginOpen && (
+        <AlertModal
+          message="로그인이 필요합니다."
+          open={isLoginOpen}
+          onClose={closeLoginModal}
+          showCancelButton={true}
         />
       )}
     </Modal>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useLoginStore } from "@/store/useLoginStore";
+import { useRouter } from "next/navigation";
+import React, { createContext, ReactNode } from "react";
+
+type AuthContextType = {
+  isChecked: boolean;
+};
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  // router
+  const router = useRouter();
+
+  // 로그인 전역상태
+  const { isLogin } = useLoginStore();
+
+  // effect 훅으로 로그인 상태 - 체크 여부
+  const [isChecked, setIsChecked] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!isLogin) {
+      router.replace("/");
+    } else {
+      setIsChecked(true);
+    }
+  }, [isLogin]);
+
+  if (!isChecked) return null; // 렌더링 막기
+
+  return (
+    <AuthContext.Provider value={{ isChecked }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import React from "react";
+
+interface IToastProvider {
+  message: string;
+  isOpen: boolean;
+  openToast: (message: string) => void;
+  closeToast: () => void;
+}
+
+const ToastContext = React.createContext<IToastProvider | null>(null);
+
+export default function ToastProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [message, setMessage] = React.useState<string>("");
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const [fade, setFade] = React.useState(false);
+  const timerRef = React.useRef<NodeJS.Timeout | null>(null);
+
+  const closeToast = () => {
+    setFade(true); // fade-out 시작
+
+    setTimeout(() => {
+      setIsOpen(false);
+      setFade(false); // 초기화
+      setMessage("");
+    }, 500);
+  };
+
+  const openToast = (msg: string) => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    } // 기존 타이머 정리
+
+    setMessage(msg);
+    setIsOpen(true);
+
+    timerRef.current = setTimeout(() => {
+      closeToast();
+    }, 3000); // 3초 후 자동 닫힘
+  };
+
+  return (
+    <ToastContext.Provider value={{ message, isOpen, openToast, closeToast }}>
+      {isOpen && (
+        <div
+          className={`fixed bottom-10 left-1/3 z-50 -translate-x-1/2 cursor-pointer rounded-lg bg-black px-4 py-2 text-white shadow-lg ${fade ? "animate-fade-out" : ""}`}
+          onClick={closeToast}
+        >
+          {message}
+        </div>
+      )}
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = React.useContext(ToastContext);
+
+  if (!context) {
+    throw new Error("useToast must be used within ToastProvider");
+  }
+
+  return context;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/context/**/*.{js,ts,jsx,tsx,mdx}", // ToastContext 등 사용
   ],
   theme: {
     extend: {
@@ -12,6 +13,15 @@ const config: Config = {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+      },
+      keyframes: {
+        fadeOut: {
+          "0%": { opacity: "1" },
+          "100%": { opacity: "0" },
+        },
+      },
+      animation: {
+        "fade-out": "fadeOut 0.5s ease-out forwards",
       },
     },
   },


### PR DESCRIPTION
### [Feat:[layout] 인증여부 필요한 페이지 - AuthContext context api 도입하여 체크](https://github.com/changmoolee/joseph-instagram/commit/ccb98c1def6377a955f108a90a28176465c1c7f4)
- 마이페이지, 게시물 페이지 등 layout 페이지 생성 후 provider로 적용

### [Feat:[ToastContext] Toast ui 사용가능한 전역context 추가(layout)](https://github.com/changmoolee/joseph-instagram/commit/23fdb3c957fcb8d04906e5cf7cfeeea0e654b413)
- 현재는 적용된 페이지 없음

### [Feat:[AlertModal] 기존 브라우저alert 대체할 AlertModal 추가](https://github.com/changmoolee/joseph-instagram/commit/d90c5655258a49f928fb7f262b579cb7f58dc2f7)
- 기존 로그인 관련 alert 모두 대체 