### PR TITLE
Feat:[로그인] 카카오 계정 로그인 - 1. 이메일 인증코드 발송 2. 인증코드 확인 절차 구현 완료

### DIFF
--- a/src/app/api/auth-code/send/route.ts
+++ b/src/app/api/auth-code/send/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email } = await req.json();
+
+    if (!process.env.MAIL_AUTH_CODE_API_KEY) {
+      throw new Error(
+        "환경변수 MAIL_AUTH_CODE_API_KEY가 설정되어 있지 않습니다."
+      );
+    }
+
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_NESTJS_SERVER}/auth-code/send`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          /** 외부 발송을 막기 위한 비공개 키 */
+          "x-app-secret": process.env.MAIL_AUTH_CODE_API_KEY,
+        },
+        body: JSON.stringify({ email }),
+      }
+    );
+
+    return response;
+  } catch (error: any) {
+    throw error;
+  }
+}

--- a/src/app/auth/google/page.tsx
+++ b/src/app/auth/google/page.tsx
@@ -28,29 +28,27 @@ export default function AuthGooglePage({
     if (!code) return;
 
     const handleGoogleAuth = async () => {
-      try {
-        const authGoogleResponse = await authGoogle({ code });
+      const authGoogleResponse = await authGoogle({ code });
 
-        const { result, data: responseData, message } = authGoogleResponse;
+      const { result, data: responseData, message } = authGoogleResponse;
 
-        if (result === "success" && responseData) {
-          // 로그인 전역상태
-          excuteLogin({
-            id: responseData.id,
-            email: responseData.email,
-            image_url: responseData.image_url,
-            username: responseData.username,
-          });
-          // 메인페이지로 이동
-          router.push("/");
-        }
+      if (result === "success" && responseData) {
+        // 로그인 전역상태
+        excuteLogin({
+          id: responseData.id,
+          email: responseData.email,
+          image_url: responseData.image_url,
+          username: responseData.username,
+        });
+        // 메인페이지로 이동
+        router.push("/");
+      }
 
-        if (result === "failure") {
-          // 에러메시지
-          alert(message);
-        }
-      } catch (error) {
-        console.error("Google 로그인 실패", error);
+      if (result === "failure") {
+        // 에러메시지
+        alert(message);
+        // 메인페이지로 이동
+        router.push("/");
       }
     };
 

--- a/src/app/auth/kakao/page.tsx
+++ b/src/app/auth/kakao/page.tsx
@@ -7,6 +7,10 @@ import { authKakao, authKakaoSignup } from "@/utils/services/auth/kakao";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { IKakaoSignInResult } from "@/typescript/auth.interface";
 import ColorButton from "@/components/ColorButton/ColorButton.component";
+import { sendAuthCode, verifyAuthCode } from "@/utils/services/auth/auth-code";
+import { useModal } from "@/hooks/components/useModal";
+import AlertModal from "@/components/AlertModal/AlertModal.component";
+import Loading from "@/components/Loading/Loading.component";
 
 interface ISearchParams {
   /** 토큰 받기 요청에 필요한 인가 코드 */
@@ -22,6 +26,10 @@ export interface IEmailFormValues {
   email: string;
 }
 
+export interface IAuthCodeFormValues {
+  code: string;
+}
+
 export default function AuthKakaoPage({
   searchParams,
 }: {
@@ -33,14 +41,28 @@ export default function AuthKakaoPage({
 
   const excuteLogin = useLoginStore((state) => state.excuteLogin);
 
+  const { isOpen, message, openModal, closeModal } = useModal();
+
   const {
-    register,
-    formState: { errors },
-    handleSubmit,
+    register: emailRegister,
+    formState: { errors: emailErrors },
+    watch: emailWatch,
+    handleSubmit: emailHandleSubmit,
   } = useForm<IEmailFormValues>();
+
+  const {
+    register: authCodeRegister,
+    formState: { errors: authCodeErrors },
+    handleSubmit: authCodeHandleSubmit,
+  } = useForm<IAuthCodeFormValues>();
 
   const [kakaoUserinfo, setKakaoUserinfo] =
     React.useState<IKakaoSignInResult>();
+
+  const [isEmailConfirmed, setIsEmailConfirmed] = React.useState(false);
+
+  const [showAuthCodeInput, setShowAuthCodeInput] =
+    React.useState<boolean>(false);
 
   React.useEffect(() => {
     if (!code || error) {
@@ -87,49 +109,90 @@ export default function AuthKakaoPage({
   }, [code, router]);
 
   /**
-   * 카카오 소셜로그인 - 회원가입 submit
+   * 카카오 소셜로그인 - 이메일 인증코드 발송
    */
-  const onSubmit: SubmitHandler<IEmailFormValues> = async (
+  const onSubmitEmail: SubmitHandler<IEmailFormValues> = async (
     data: IEmailFormValues
   ) => {
     if (!confirm("정확한 이메일주소를 입력하셨나요?")) {
       return;
     }
 
-    if (!kakaoUserinfo) {
-      throw new Error(
-        "카카오 유저 정보가 없습니다. 새로고침 후 다시 시도해주세요."
-      );
-    }
+    // 이메일 확정
+    setIsEmailConfirmed(true);
 
-    // 카카오로부터 받아온 회원정보 상태값
-    const { provider_id, image_url, username } = kakaoUserinfo;
+    const authCodeResponse = await sendAuthCode({ email: data.email });
 
-    /** 카카오 소셜 로그인 - 회원가입 api 응답값 */
-    const kakaoSignupResponse = await authKakaoSignup({
-      email: data.email,
-      provider_id: provider_id.toString(), // 모든 provider_id는 string으로 통일
-      image_url,
-      username,
-    });
+    const { result, message } = authCodeResponse;
 
-    const { result, data: signuResponseData, message } = kakaoSignupResponse;
-
-    if (result === "success" && signuResponseData) {
-      // 로그인 전역상태
-      excuteLogin({
-        id: signuResponseData.id,
-        email: signuResponseData.email,
-        image_url: signuResponseData.image_url,
-        username: signuResponseData.username,
-      });
-      // 메인페이지로 이동
-      router.push("/");
+    if (result === "success") {
+      openModal(message);
+      // 인증코드 입력 input창 생성
+      setShowAuthCodeInput(true);
     }
 
     if (result === "failure") {
       // 에러메시지
-      alert(message);
+      openModal(message);
+    }
+  };
+
+  /**
+   * 카카오 소셜로그인 - 인증코드 확인
+   */
+  const onSubmitAuthCode: SubmitHandler<IAuthCodeFormValues> = async (
+    data: IAuthCodeFormValues
+  ) => {
+    // 인증 코드 확인 api
+    const authCodeResponse = await verifyAuthCode({
+      email: emailWatch("email"),
+      code: data.code,
+    });
+
+    const { result, message } = authCodeResponse;
+
+    // 인증코드 확인 성공시 회원가입을 한다.
+    if (result === "success") {
+      if (!kakaoUserinfo) {
+        openModal("카카오 유저 정보가 없습니다. 다시 로그인을 진행해주세요.");
+        router.push("/");
+        return;
+      }
+
+      // 카카오로부터 받아온 회원정보 상태값
+      const { provider_id, image_url, username } = kakaoUserinfo;
+
+      /** 카카오 소셜 로그인 - 회원가입 api 응답값 */
+      const kakaoSignupResponse = await authKakaoSignup({
+        email: emailWatch("email"),
+        provider_id: provider_id.toString(), // 모든 provider_id는 string으로 통일
+        image_url,
+        username,
+      });
+
+      const { result, data: signuResponseData, message } = kakaoSignupResponse;
+
+      if (result === "success" && signuResponseData) {
+        // 로그인 전역상태
+        excuteLogin({
+          id: signuResponseData.id,
+          email: signuResponseData.email,
+          image_url: signuResponseData.image_url,
+          username: signuResponseData.username,
+        });
+        openModal("카카오 로그인이 완료되었습니다!");
+        // 메인페이지로 이동
+        router.push("/");
+      }
+      if (result === "failure") {
+        // 에러메시지
+        message && openModal(message);
+      }
+    }
+
+    if (result === "failure") {
+      // 에러메시지
+      openModal(message);
     }
   };
 
@@ -146,31 +209,88 @@ export default function AuthKakaoPage({
     <main>
       {/* 회원 정보가 있을 경우, 이메일 입력을 위한 폼을 보여줍니다. */}
       {kakaoUserinfo ? (
-        <form
-          className="flex h-[200px] w-full flex-col items-center justify-center"
-          onSubmit={handleSubmit(onSubmit)}
-        >
-          <div>
-            <article className="flex h-[40px] gap-5">
-              <input
-                className="w-[200px] border p-2"
-                placeholder="abc1234@gmail.com"
-                {...register("email", { required: true })}
-              />
-              <ColorButton
-                type="submit"
-                text="등록"
-                className="flex h-full w-[50px] items-center justify-center bg-blue-500"
-              />
-            </article>
-            {errors.email && (
-              <span className="text-[red]">이메일을 입력해 주세요.</span>
+        <div>
+          {/* 1. 이메일 입력 폼 */}
+          <form
+            className="flex h-[200px] w-full flex-col items-center justify-center"
+            onSubmit={emailHandleSubmit(onSubmitEmail)}
+          >
+            <section>
+              <article className="flex flex-col whitespace-pre-wrap">
+                <span className="text-[20px]">💬 이메일 주소가 필요해요.</span>
+                <p className="mt-[10px] text-[14px]">{`카카오 소셜 로그인을 이용하시려면,\n사용가능한 이메일 주소를 인증하세요.`}</p>
+              </article>
+              <article className="mt-[20px]">
+                <article className="flex h-[40px] gap-5">
+                  <input
+                    className="w-[200px] border p-2"
+                    placeholder="abc1234@gmail.com"
+                    disabled={isEmailConfirmed} // 이메일 발송 이후 변경 불가
+                    {...emailRegister("email", { required: true })}
+                  />
+                  <ColorButton
+                    type="submit"
+                    text="다음"
+                    className={`flex h-full w-[50px] items-center justify-center bg-blue-500 ${isEmailConfirmed ? "cursor-not-allowed opacity-50" : ""}`}
+                    disabled={isEmailConfirmed} // 이메일 발송 이후 변경 불가
+                  />
+                </article>
+                {emailErrors.email && (
+                  <span className="text-[red]">이메일을 입력해 주세요.</span>
+                )}
+              </article>
+            </section>
+          </form>
+
+          {/* 2. 인증코드 입력 폼 */}
+          <form
+            className="flex w-full flex-col items-center justify-center"
+            onSubmit={authCodeHandleSubmit(onSubmitAuthCode)}
+          >
+            {/** 이메일 발송 api 로딩 */}
+            {!showAuthCodeInput && <Loading isActive={isEmailConfirmed} />}
+
+            {/* 인증코드 입력 input창 생성 */}
+            {showAuthCodeInput && (
+              <section>
+                <article className="flex flex-col whitespace-pre-wrap">
+                  <span className="text-[20px]">✅ 인증코드 입력</span>
+                </article>
+                <article className="mt-[20px]">
+                  <article className="flex h-[40px] gap-5">
+                    <input
+                      className="w-[200px] border p-2"
+                      placeholder="인증코드 6자리"
+                      {...authCodeRegister("code", { required: true })}
+                    />
+                    <ColorButton
+                      type="submit"
+                      text="인증"
+                      className="flex h-full w-[50px] items-center justify-center bg-black"
+                    />
+                  </article>
+                  {authCodeErrors.code && (
+                    <span className="text-[red]">
+                      인증코드 6자리를 입력해 주세요.
+                    </span>
+                  )}
+                </article>
+              </section>
             )}
-          </div>
-        </form>
+          </form>
+        </div>
       ) : (
         // 카카오 소셜 로그인
         <p className="py-10 text-center">로그인 처리 중입니다...</p>
+      )}
+
+      {isOpen && (
+        <AlertModal
+          message={message}
+          open={isOpen}
+          onClose={closeModal}
+          confirmAction={closeModal}
+        />
       )}
     </main>
   );

--- a/src/app/auth/kakao/page.tsx
+++ b/src/app/auth/kakao/page.tsx
@@ -48,39 +48,38 @@ export default function AuthKakaoPage({
     }
 
     const handleKakaoAuth = async () => {
-      try {
-        const authKakaoResponse = await authKakao({ code });
+      const authKakaoResponse = await authKakao({ code });
 
-        const { result, data: responseData, message } = authKakaoResponse;
+      const { result, data: responseData, message } = authKakaoResponse;
 
-        if (result === "success" && responseData) {
+      if (result === "success" && responseData) {
+        /**
+         * 응답값에 토큰이 존재할 경우, 로그인 처리
+         */
+        if ("token" in responseData) {
+          // 로그인 전역상태
+          excuteLogin({
+            id: responseData.id,
+            email: responseData.email,
+            image_url: responseData.image_url,
+            username: responseData.username,
+          });
+          // 메인페이지로 이동
+          router.push("/");
+        } else {
           /**
-           * 응답값에 토큰이 존재할 경우, 로그인 처리
+           * 응답값에 토큰이 없을 경우, 회원가입을 위한 회원정보를 상태에 저장
            */
-          if ("token" in responseData) {
-            // 로그인 전역상태
-            excuteLogin({
-              id: responseData.id,
-              email: responseData.email,
-              image_url: responseData.image_url,
-              username: responseData.username,
-            });
-            // 메인페이지로 이동
-            router.push("/");
-          } else {
-            /**
-             * 응답값에 토큰이 없을 경우, 회원가입을 위한 회원정보를 상태에 저장
-             */
-            setKakaoUserinfo(responseData);
-          }
+          setKakaoUserinfo(responseData);
         }
+      }
 
-        if (result === "failure") {
-          // 에러메시지
-          alert(message);
-        }
-      } catch (error) {
+      if (result === "failure") {
+        // 에러메시지
+        alert(message);
         console.error("kakao 로그인 실패", error);
+        // 메인페이지로 이동
+        router.push("/");
       }
     };
 

--- a/src/app/auth/naver/page.tsx
+++ b/src/app/auth/naver/page.tsx
@@ -37,29 +37,28 @@ export default function AuthNaverPage({
     }
 
     const handleNaverAuth = async () => {
-      try {
-        const authNaverResponse = await authNaver({ code, state });
+      const authNaverResponse = await authNaver({ code, state });
 
-        const { result, data: responseData, message } = authNaverResponse;
+      const { result, data: responseData, message } = authNaverResponse;
 
-        if (result === "success" && responseData) {
-          // 로그인 전역상태
-          excuteLogin({
-            id: responseData.id,
-            email: responseData.email,
-            image_url: responseData.image_url,
-            username: responseData.username,
-          });
-          // 메인페이지로 이동
-          router.push("/");
-        }
+      if (result === "success" && responseData) {
+        // 로그인 전역상태
+        excuteLogin({
+          id: responseData.id,
+          email: responseData.email,
+          image_url: responseData.image_url,
+          username: responseData.username,
+        });
+        // 메인페이지로 이동
+        router.push("/");
+      }
 
-        if (result === "failure") {
-          // 에러메시지
-          alert(message);
-        }
-      } catch (error) {
+      if (result === "failure") {
+        // 에러메시지
+        alert(message);
         console.error("naver 로그인 실패", error);
+        // 메인페이지로 이동
+        router.push("/");
       }
     };
 

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -39,6 +39,7 @@ export default function User({ params }: { params: { user_id: string } }) {
 
   const {
     isOpen: isLoginOpen,
+    message: loginMessage,
     openModal: openLoginModal,
     closeModal: closeLoginModal,
   } = useModal();
@@ -66,7 +67,7 @@ export default function User({ params }: { params: { user_id: string } }) {
 
   const excuteFollowApi = async (userData: IUserInfo) => {
     if (!userInfo?.id) {
-      openLoginModal();
+      openLoginModal("로그인이 필요합니다.");
       return;
     }
 
@@ -118,7 +119,7 @@ export default function User({ params }: { params: { user_id: string } }) {
                         if (isLogin && userData) {
                           excuteFollowApi(userData);
                         } else {
-                          openLoginModal();
+                          openLoginModal("로그인이 필요합니다.");
                         }
                       }}
                     />
@@ -218,7 +219,7 @@ export default function User({ params }: { params: { user_id: string } }) {
               >
                 <button
                   onClick={() => {
-                    openPostModal();
+                    openPostModal("로그인이 필요합니다.");
                     setClickedId(post.id);
                   }}
                 >
@@ -247,7 +248,7 @@ export default function User({ params }: { params: { user_id: string } }) {
 
         {isLoginOpen && (
           <AlertModal
-            message="로그인이 필요합니다."
+            message={loginMessage}
             open={isLoginOpen}
             onClose={closeLoginModal}
             showCancelButton={true}

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -14,6 +14,7 @@ import { IUserInfo } from "@/typescript/user.interface";
 import { excuteFollow } from "@/utils/services/follow";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import React from "react";
 
 /**
@@ -21,6 +22,8 @@ import React from "react";
  */
 export default function User({ params }: { params: { user_id: string } }) {
   const tabs = ["POSTS", "SAVED", "LIKED"];
+
+  const router = useRouter();
 
   const { isLogin, userInfo } = useLoginStore();
 
@@ -64,6 +67,8 @@ export default function User({ params }: { params: { user_id: string } }) {
   const isFollower = !!userData?.followers.find(
     (follower) => follower.follower.id === userInfo?.id
   );
+
+  const redirectToLogin = () => router.push("/login");
 
   const excuteFollowApi = async (userData: IUserInfo) => {
     if (!userInfo?.id) {
@@ -252,6 +257,7 @@ export default function User({ params }: { params: { user_id: string } }) {
             open={isLoginOpen}
             onClose={closeLoginModal}
             showCancelButton={true}
+            confirmAction={redirectToLogin}
           />
         )}
       </div>

--- a/src/components/AlertModal/AlertModal.component.tsx
+++ b/src/components/AlertModal/AlertModal.component.tsx
@@ -43,14 +43,14 @@ export default function AlertModal(props: IAlertModalProps) {
   return (
     <Modal open={open} onClose={onClose}>
       <section className="flex h-screen w-screen items-center justify-center">
-        <div className="flex max-h-[300px] min-h-[150px] w-[90%] max-w-[400px] flex-col justify-between rounded-lg bg-white p-[20px] pt-[30px]">
+        <div className="flex max-h-[350px] min-h-[200px] w-[80%] min-w-[200px] max-w-[350px] flex-col justify-between rounded-lg bg-white p-[20px] pt-[30px]">
           {/* 메시지 */}
           <span className="whitespace-pre-wrap text-lg font-bold">
             {message}
           </span>
 
           {/* 버튼 */}
-          <article className="mt-[10px] flex gap-2">
+          <article className="mt-[20px] flex gap-2">
             {showCancelButton && (
               <button
                 className="flex-1 rounded-md bg-gray-200 p-[5px] text-black"

--- a/src/components/AlertModal/AlertModal.component.tsx
+++ b/src/components/AlertModal/AlertModal.component.tsx
@@ -2,7 +2,6 @@
 
 import React from "react";
 import Modal from "@/components/Modal/Modal.component";
-import { useRouter } from "next/navigation";
 
 interface IAlertModalProps {
   /**
@@ -20,7 +19,11 @@ interface IAlertModalProps {
   /**
    * 취소 버튼 사용 유무
    */
-  showCancelButton: boolean;
+  showCancelButton?: boolean;
+  /**
+   * 확인 버튼 사용시 실행될 함수
+   */
+  confirmAction: () => void;
 }
 
 /**
@@ -29,21 +32,25 @@ interface IAlertModalProps {
  */
 export default function AlertModal(props: IAlertModalProps) {
   // props
-  const { open, onClose, message, showCancelButton } = props;
-
-  const router = useRouter();
-
-  const redirectToLogin = () => router.push("/login");
+  const {
+    open,
+    onClose,
+    message,
+    showCancelButton = false,
+    confirmAction,
+  } = props;
 
   return (
     <Modal open={open} onClose={onClose}>
       <section className="flex h-screen w-screen items-center justify-center">
-        <div className="flex max-h-[200px] min-h-[150px] w-[90%] max-w-[300px] flex-col justify-between rounded-lg bg-white p-[20px] pt-[30px]">
+        <div className="flex max-h-[300px] min-h-[150px] w-[90%] max-w-[400px] flex-col justify-between rounded-lg bg-white p-[20px] pt-[30px]">
           {/* 메시지 */}
-          <span className="text-lg font-bold">{message}</span>
+          <span className="whitespace-pre-wrap text-lg font-bold">
+            {message}
+          </span>
 
           {/* 버튼 */}
-          <article className="flex gap-2">
+          <article className="mt-[10px] flex gap-2">
             {showCancelButton && (
               <button
                 className="flex-1 rounded-md bg-gray-200 p-[5px] text-black"
@@ -54,7 +61,7 @@ export default function AlertModal(props: IAlertModalProps) {
             )}
             <button
               className="flex-1 rounded-md bg-blue-500 p-[5px] text-white"
-              onClick={redirectToLogin}
+              onClick={confirmAction}
             >
               확인
             </button>

--- a/src/components/Post/Post.component.tsx
+++ b/src/components/Post/Post.component.tsx
@@ -16,6 +16,7 @@ import { useModal } from "@/hooks/components/useModal";
 import { IUser } from "@/typescript/user.interface";
 import { mutate } from "swr";
 import AlertModal from "@/components/AlertModal/AlertModal.component";
+import { useRouter } from "next/navigation";
 
 // dayjs의 RelativeTime 플러그인 추가
 dayjs.extend(relativeTime);
@@ -49,6 +50,8 @@ export default function Post(props: IPostProps) {
 
   const getPostsUrlKey = `${process.env.NEXT_PUBLIC_NESTJS_SERVER}/post`;
 
+  const router = useRouter();
+
   // modal 커스텀 훅
   const {
     isOpen: isPostOpen,
@@ -65,6 +68,8 @@ export default function Post(props: IPostProps) {
 
   /** 유저 개인 프로필 전역 상태 데이터 */
   const userInfo = useLoginStore((state) => state.userInfo);
+
+  const redirectToLogin = () => router.push("/login");
 
   const excuteLikeApi = async () => {
     if (!userInfo?.id) {
@@ -169,6 +174,7 @@ export default function Post(props: IPostProps) {
           open={isLoginOpen}
           onClose={closeLoginModal}
           showCancelButton={true}
+          confirmAction={redirectToLogin}
         />
       )}
     </div>

--- a/src/components/Post/Post.component.tsx
+++ b/src/components/Post/Post.component.tsx
@@ -58,6 +58,7 @@ export default function Post(props: IPostProps) {
 
   const {
     isOpen: isLoginOpen,
+    message: loginMessage,
     openModal: openLoginModal,
     closeModal: closeLoginModal,
   } = useModal();
@@ -67,7 +68,7 @@ export default function Post(props: IPostProps) {
 
   const excuteLikeApi = async () => {
     if (!userInfo?.id) {
-      openLoginModal();
+      openLoginModal("로그인이 필요합니다.");
       return;
     }
 
@@ -85,7 +86,7 @@ export default function Post(props: IPostProps) {
 
   const excuteBookmarkApi = async () => {
     if (!userInfo?.id) {
-      openLoginModal();
+      openLoginModal("로그인이 필요합니다.");
       return;
     }
 
@@ -148,7 +149,10 @@ export default function Post(props: IPostProps) {
             <span className="text-gray-400">{dayjs(createDate).fromNow()}</span>
           </div>
         </section>
-        <CommentInput readOnly onClick={openPostModal} />
+        <CommentInput
+          readOnly
+          onClick={() => openPostModal("로그인이 필요합니다.")}
+        />
       </section>
       {isPostOpen && (
         <PostModal
@@ -161,7 +165,7 @@ export default function Post(props: IPostProps) {
 
       {isLoginOpen && (
         <AlertModal
-          message="로그인이 필요합니다."
+          message={loginMessage}
           open={isLoginOpen}
           onClose={closeLoginModal}
           showCancelButton={true}

--- a/src/components/PostModal/PostModal.component.tsx
+++ b/src/components/PostModal/PostModal.component.tsx
@@ -84,6 +84,8 @@ export default function PostModal(props: IPostModalProps) {
   /** 게시물 댓글 조회 */
   const { isLoading, data: comments } = useGetPostComments(id);
 
+  const redirectToLogin = () => router.push("/login");
+
   const deletePostApi = async () => {
     if (!userInfo?.id) {
       openLoginModal("로그인이 필요합니다.");
@@ -276,6 +278,7 @@ export default function PostModal(props: IPostModalProps) {
           open={isLoginOpen}
           onClose={closeLoginModal}
           showCancelButton={true}
+          confirmAction={redirectToLogin}
         />
       )}
     </Modal>

--- a/src/components/PostModal/PostModal.component.tsx
+++ b/src/components/PostModal/PostModal.component.tsx
@@ -67,6 +67,7 @@ export default function PostModal(props: IPostModalProps) {
   // modal 커스텀 훅
   const {
     isOpen: isCommentOpen,
+    message: commentMessage,
     openModal: openCommentModal,
     closeModal: closeCommentModal,
   } = useModal();
@@ -85,7 +86,7 @@ export default function PostModal(props: IPostModalProps) {
 
   const deletePostApi = async () => {
     if (!userInfo?.id) {
-      openLoginModal();
+      openLoginModal("로그인이 필요합니다.");
       return;
     }
 
@@ -111,7 +112,7 @@ export default function PostModal(props: IPostModalProps) {
 
   const makeCommentApi = async () => {
     if (!userInfo?.id) {
-      openLoginModal();
+      openLoginModal("로그인이 필요합니다.");
       return;
     }
 
@@ -132,7 +133,7 @@ export default function PostModal(props: IPostModalProps) {
 
   const excuteLikeApi = async () => {
     if (!userInfo?.id) {
-      openLoginModal();
+      openLoginModal("로그인이 필요합니다.");
       return;
     }
 
@@ -150,7 +151,7 @@ export default function PostModal(props: IPostModalProps) {
 
   const excuteBookmarkApi = async () => {
     if (!userInfo?.id) {
-      openLoginModal();
+      openLoginModal("로그인이 필요합니다.");
       return;
     }
 
@@ -219,7 +220,7 @@ export default function PostModal(props: IPostModalProps) {
             <div className="flex justify-end p-[10px] lg:hidden">
               <button
                 className="text-[14px] text-gray-400 underline"
-                onClick={openCommentModal}
+                onClick={() => openCommentModal("로그인이 필요합니다.")}
               >
                 댓글보기
               </button>
@@ -271,7 +272,7 @@ export default function PostModal(props: IPostModalProps) {
       {/* 로그인 검증 모달 */}
       {isLoginOpen && (
         <AlertModal
-          message="로그인이 필요합니다."
+          message={commentMessage}
           open={isLoginOpen}
           onClose={closeLoginModal}
           showCancelButton={true}

--- a/src/hooks/components/useModal.tsx
+++ b/src/hooks/components/useModal.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
 
 export function useModal() {
-  const [isOpen, setIsOpen] = useState(false);
+  const [message, setMessage] = useState("");
 
-  const openModal = () => setIsOpen(true);
+  const openModal = (message: string) => {
+    setMessage(message);
+  };
 
-  const closeModal = () => setIsOpen(false);
+  const closeModal = () => setMessage("");
 
-  return { isOpen, openModal, closeModal };
+  return { isOpen: !!message, message, openModal, closeModal };
 }

--- a/src/utils/services/auth/auth-code.ts
+++ b/src/utils/services/auth/auth-code.ts
@@ -1,0 +1,61 @@
+import apiClient from "@/utils/axios";
+
+interface ISendAuthCodeToEmail {
+  email: string;
+}
+
+/**
+ * 인증코드 발신 api
+ * @description
+ * - 특정 이메일주소에 6자리 인증코드가 담긴 이메일을 발신한다.
+ * - 앱에서만 api 요청 가능할 수 있도록, Nextjs api routes를 거친다.
+ */
+export const sendAuthCode = async (props: ISendAuthCodeToEmail) => {
+  try {
+    const { email } = props;
+
+    const response = await apiClient.post(`/api/auth-code/send`, {
+      email,
+    });
+
+    return response.data;
+  } catch (error: any) {
+    return {
+      data: null,
+      result: "failure",
+      message: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+interface IVerifyAuthCode {
+  email: string;
+  code: string;
+}
+
+/**
+ * 인증코드 확인 api
+ * @description
+ * - 회원이 입력한 6자리 인증코드를 백엔드 서버에서 확인한다.
+ */
+export const verifyAuthCode = async (props: IVerifyAuthCode) => {
+  try {
+    const { email, code } = props;
+
+    const response = await apiClient.post(
+      `${process.env.NEXT_PUBLIC_NESTJS_SERVER}/auth-code/verify`,
+      {
+        email,
+        code,
+      }
+    );
+
+    return response.data;
+  } catch (error: any) {
+    return {
+      data: null,
+      result: "failure",
+      message: error.response?.data?.message || error.message,
+    };
+  }
+};


### PR DESCRIPTION
### [Feat:[로그인] 카카오 계정 로그인 - 1. 이메일 인증코드 발송 2. 인증코드 확인 절차 구현 완료](https://github.com/changmoolee/joseph-instagram/commit/c40e60f4924926626bbdca4ce3194a647ddaacbf)
- 이메일 발송의 경우 nextjs routes api를 경유 (외부 api 요청 방지)
- 카카오 리다이렉트 페이지는 2개의 form으로 구현됨.(이메일 입력 form, 인증코드 입력 form)

### 그밖에
- useModal 훅의 props 및 내부 로직  변경 - message prop 유무가 모달 구현 여부 결정
- AlertModal 컴포넌트 - 디자인 변경 및 confirmAction prop 추가