### PR TITLE
Update:[로그인 전역상태] provider 필드 추가 / Feat:[비밀번호 재인증] 페이지 및 api 추가

### DIFF
--- a/src/app/auth/google/page.tsx
+++ b/src/app/auth/google/page.tsx
@@ -39,6 +39,7 @@ export default function AuthGooglePage({
           email: responseData.email,
           image_url: responseData.image_url,
           username: responseData.username,
+          provider: responseData.provider,
         });
         // 메인페이지로 이동
         router.push("/");
@@ -53,7 +54,7 @@ export default function AuthGooglePage({
     };
 
     handleGoogleAuth();
-  }, [code, router]);
+  }, [code, router, excuteLogin]);
 
   return <p className="py-10 text-center">로그인 처리 중입니다...</p>;
 }

--- a/src/app/auth/kakao/page.tsx
+++ b/src/app/auth/kakao/page.tsx
@@ -85,6 +85,7 @@ export default function AuthKakaoPage({
             email: responseData.email,
             image_url: responseData.image_url,
             username: responseData.username,
+            provider: responseData.provider,
           });
           // 메인페이지로 이동
           router.push("/");
@@ -106,7 +107,7 @@ export default function AuthKakaoPage({
     };
 
     handleKakaoAuth();
-  }, [code, router]);
+  }, [code, error, router, excuteLogin]);
 
   /**
    * 카카오 소셜로그인 - 이메일 인증코드 발송
@@ -179,6 +180,7 @@ export default function AuthKakaoPage({
           email: signuResponseData.email,
           image_url: signuResponseData.image_url,
           username: signuResponseData.username,
+          provider: signuResponseData.provider,
         });
         openModal("카카오 로그인이 완료되었습니다!");
         // 메인페이지로 이동

--- a/src/app/auth/naver/page.tsx
+++ b/src/app/auth/naver/page.tsx
@@ -48,6 +48,7 @@ export default function AuthNaverPage({
           email: responseData.email,
           image_url: responseData.image_url,
           username: responseData.username,
+          provider: responseData.provider,
         });
         // 메인페이지로 이동
         router.push("/");
@@ -63,7 +64,7 @@ export default function AuthNaverPage({
     };
 
     handleNaverAuth();
-  }, [code, router]);
+  }, [code, state, error, router, excuteLogin]);
 
   // 네이버 인증 실패 시
   if (!code || error || !state) {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -50,6 +50,7 @@ export default function Login() {
         email: responseData.email,
         image_url: responseData.image_url,
         username: responseData.username,
+        provider: responseData.provider,
       });
       // 메인페이지로 이동
       router.push("/");

--- a/src/app/my-page/edit/page.tsx
+++ b/src/app/my-page/edit/page.tsx
@@ -9,6 +9,7 @@ import { ICommonResponse } from "@/typescript/common/response.interface";
 import { ImageUpload } from "@/utils/services/upload";
 import apiClient from "@/utils/axios";
 import { useLoginStore } from "@/store/useLoginStore";
+import { useEditVerificationStore } from "@/store/useEditVerificationStore";
 
 /**
  * 마이 페이지 수정
@@ -22,6 +23,9 @@ export default function MyPageEdit() {
 
   /** 유저 개인 프로필 전역 상태 데이터 */
   const userInfo = useLoginStore((state) => state.userInfo);
+
+  /** 비밀번호 재입력 인증 여부 전역 상태 데이터 */
+  const { isVerified } = useEditVerificationStore();
 
   // useForm
   const {
@@ -93,9 +97,6 @@ export default function MyPageEdit() {
           username,
           ...(imageData && { image: imageData }),
         });
-
-      // 메인페이지 이동
-      router.push("/");
     }
 
     // 프로필 데이터 수정이 실패했을 경우
@@ -109,100 +110,113 @@ export default function MyPageEdit() {
     updateUser(data);
   };
 
+  React.useEffect(() => {
+    if (!isVerified) {
+      alert("잘못된 접근입니다.");
+      // 메인페이지 이동
+      router.push("/");
+    }
+  }, [isVerified, router]);
+
   return (
     <main className="flex w-full justify-center">
-      <form
-        className="flex h-full w-full max-w-[400px] flex-col px-[20px]"
-        onSubmit={handleSubmit(onSubmit)}
-      >
-        <section className="mb-10 mt-10 flex w-full justify-center lg:mb-20">
-          <span className="text-xl font-[600]">내정보 수정</span>
-        </section>
+      {/* 비밀번호 재입력 인증 전역상태 - true일때 구현 */}
+      {isVerified && (
+        <form
+          className="flex h-full w-full max-w-[400px] flex-col px-[20px]"
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <section className="mb-10 mt-10 flex w-full justify-center lg:mb-20">
+            <span className="text-xl font-[600]">내정보 수정</span>
+          </section>
 
-        {/* 프로필 이미지 수정 */}
-        <SignupDragAndDrop
-          className="h-[200px] lg:h-[300px]"
-          prevSrc={watch("image_url")}
-          onChange={(file) => {
-            setImageFile(file);
-          }}
-        />
+          {/* 프로필 이미지 수정 */}
+          <SignupDragAndDrop
+            className="h-[200px] lg:h-[300px]"
+            prevSrc={watch("image_url")}
+            onChange={(file) => {
+              setImageFile(file);
+            }}
+          />
 
-        <section className="mt-10 flex w-full flex-col gap-10">
-          <article className="w-full gap-5">
-            <section className="flex w-full">
-              <span className="w-[200px]">이메일</span>
-              <input
-                disabled
-                className="w-full"
-                placeholder="abc1234@gmail.com"
-                {...register("email", {
-                  required: true,
-                })}
-              />
-            </section>
-            {errors.email && (
-              <span className="text-[red]">이메일을 입력해 주세요.</span>
-            )}
-          </article>
+          <section className="mt-10 flex w-full flex-col gap-10">
+            <article className="w-full gap-5">
+              <section className="flex w-full">
+                <span className="w-[200px]">이메일</span>
+                <input
+                  disabled
+                  className="w-full"
+                  placeholder="abc1234@gmail.com"
+                  {...register("email", {
+                    required: true,
+                  })}
+                />
+              </section>
+              {errors.email && (
+                <span className="text-[red]">이메일을 입력해 주세요.</span>
+              )}
+            </article>
 
-          {/* 이름 수정 */}
-          <article className="w-full gap-5">
-            <section className="flex w-full">
-              <span className="w-[200px]">이름</span>
-              <input
-                className="w-full"
-                placeholder="홍길동"
-                {...register("username", {
-                  required: true,
-                })}
-              />
-            </section>
-            {errors.username && (
-              <span className="text-[red]">이름을 입력해 주세요.</span>
-            )}
-          </article>
+            {/* 이름 수정 */}
+            <article className="w-full gap-5">
+              <section className="flex w-full">
+                <span className="w-[200px]">이름</span>
+                <input
+                  className="w-full"
+                  placeholder="홍길동"
+                  {...register("username", {
+                    required: true,
+                  })}
+                />
+              </section>
+              {errors.username && (
+                <span className="text-[red]">이름을 입력해 주세요.</span>
+              )}
+            </article>
 
-          {/* 비밀번호 수정 */}
-          <article className="w-full gap-5">
-            <section className="flex w-full">
-              <span className="w-[200px]">비밀번호</span>
-              <input
-                className="w-full"
-                type="password"
-                placeholder="password"
-                {...register("password", { required: false })}
-              />
-            </section>
-            {errors.password && (
-              <span className="text-[red]">비밀번호를 입력해 주세요.</span>
-            )}
-          </article>
+            {/* 비밀번호 수정 */}
+            <article className="w-full gap-5">
+              <section className="flex w-full">
+                <span className="w-[200px]">비밀번호</span>
+                <input
+                  className="w-full"
+                  type="password"
+                  placeholder="password"
+                  {...register("password", { required: false })}
+                />
+              </section>
+              {errors.password && (
+                <span className="text-[red]">비밀번호를 입력해 주세요.</span>
+              )}
+            </article>
 
-          <article className="w-full gap-5">
-            <section className="flex w-full">
-              <span className="w-[200px]">비밀번호 확인</span>
-              <input
-                className="w-full"
-                type="password"
-                placeholder="verify password"
-                {...register("verifyPassword", {
-                  validate: (v) => watch("password") == v,
-                  disabled: !watch("password"),
-                })}
-              />
-            </section>
-            {errors.verifyPassword && (
-              <span className="text-[red]">비밀번호가 일치하지 않습니다.</span>
-            )}
-          </article>
-        </section>
+            <article className="w-full gap-5">
+              <section className="flex w-full">
+                <span className="w-[200px]">비밀번호 확인</span>
+                <input
+                  className="w-full"
+                  type="password"
+                  placeholder="verify password"
+                  {...register("verifyPassword", {
+                    validate: (v) => watch("password") == v,
+                    disabled: !watch("password"),
+                  })}
+                />
+              </section>
+              {errors.verifyPassword && (
+                <span className="text-[red]">
+                  비밀번호가 일치하지 않습니다.
+                </span>
+              )}
+            </article>
+          </section>
 
-        <ColorButton
-          text="수정하기"
-          className="mt-10 h-[40px] w-full bg-blue-500"
-        />
-      </form>
+          <ColorButton
+            text="수정하기"
+            className="mt-10 h-[40px] w-full bg-blue-500"
+          />
+        </form>
+      )}
     </main>
   );
 }

--- a/src/app/my-page/edit/verify-password/page.tsx
+++ b/src/app/my-page/edit/verify-password/page.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import ColorButton from "@/components/ColorButton/ColorButton.component";
+import { useRouter } from "next/navigation";
+import React from "react";
+import { useForm } from "react-hook-form";
+import { vefifyPassword } from "@/utils/services/user";
+import { useLoginStore } from "@/store/useLoginStore";
+import { useEditVerificationStore } from "@/store/useEditVerificationStore";
+
+export interface IVerifyPasswordFormValues {
+  password: string;
+}
+
+/**
+ * 비밀번호 재입력 인증 페이지
+ */
+export default function VerifyPassword() {
+  // router
+  const router = useRouter();
+
+  /** 유저 개인 프로필 전역 상태 데이터 */
+  const userInfo = useLoginStore((state) => state.userInfo);
+
+  /** 비밀번호 재입력 인증 여부 전역 상태 데이터 */
+  const { setIsVerified } = useEditVerificationStore();
+
+  const [isSocialLogin, setIsSocialLogin] = React.useState(true);
+
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<IVerifyPasswordFormValues>({
+    values: {
+      password: "",
+    },
+  });
+
+  /**
+   * 비밀번호 재입력 인증
+   */
+  const verifyPassword = async (params: IVerifyPasswordFormValues) => {
+    // 이미지 파일을 제외한 데이터
+    const { password } = params;
+
+    /**
+     * 비밀번호 재입력 인증 api 호출 결과
+     */
+    const response = await vefifyPassword({ password });
+
+    const { result, message } = response;
+
+    // 비밀번호 재입력 인증이 성공적일 경우
+    if (result === "success") {
+      alert(message);
+
+      // 비밀번호 재입력 인증 전역상태 - true
+      setIsVerified(true);
+      // 메인페이지 이동
+      router.push("/my-page/edit");
+    }
+
+    // 비밀번호 재입력 인증이 실패했을 경우
+    if (result === "failure") {
+      // 에러메시지
+      alert(message);
+    }
+  };
+
+  const onSubmit = (data: IVerifyPasswordFormValues) => {
+    verifyPassword(data);
+  };
+
+  React.useEffect(() => {
+    if (!userInfo) {
+      return;
+    }
+
+    /* provider 가 null 이면
+       소셜로그인이 아닌 '일반 로그인'이므로 비밀번호 재인증 필요 */
+    if (userInfo.provider === null) {
+      setIsSocialLogin(false);
+    } else {
+      // 소셜로그인 이라면, 비밀번호 재입력 인증 전역상태 - true
+      setIsVerified(true);
+      // 내정보수정 페이지로 이동
+      router.push("/my-page/edit");
+    }
+  }, [userInfo, router, setIsVerified]);
+
+  return (
+    <main className="flex w-full justify-center">
+      {/* 소셜로그인이 아닐때 활성화 */}
+      {!isSocialLogin && (
+        <form
+          className="flex h-full w-full max-w-[400px] flex-col px-[20px]"
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <section className="mt-10 flex w-full justify-center">
+            <span className="text-xl font-[600]">비밀번호 재인증</span>
+          </section>
+
+          <section className="mt-10 flex w-full flex-col gap-10">
+            <span className="text-sm">
+              내정보수정을 위해서 비밀번호 재인증이 필요합니다.
+            </span>
+
+            {/* 비밀번호 입력 */}
+            <article className="w-full gap-5">
+              <section className="flex w-full">
+                <span className="w-[200px]">비밀번호</span>
+                <input
+                  className="w-full"
+                  type="password"
+                  placeholder="password"
+                  {...register("password", { required: false })}
+                />
+              </section>
+              {errors.password && (
+                <span className="text-[red]">비밀번호를 입력해 주세요.</span>
+              )}
+            </article>
+          </section>
+
+          <ColorButton
+            text="인증"
+            className="mt-10 h-[40px] w-full bg-blue-500"
+          />
+        </form>
+      )}
+    </main>
+  );
+}

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -95,7 +95,7 @@ export default function MyPage() {
         {/* 내정보 수정 페이지 이동*/}
         <Link
           className={`flex h-[40px] w-full items-center justify-center rounded-md bg-blue-500 text-[#fff]`}
-          href={"/my-page/edit"}
+          href={"/my-page/edit/verify-password"}
         >
           내정보 수정하기
         </Link>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -26,7 +26,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     } else {
       setIsChecked(true);
     }
-  }, [isLogin]);
+  }, [isLogin, router]);
 
   if (!isChecked) return null; // 렌더링 막기
 

--- a/src/store/useEditVerificationStore.ts
+++ b/src/store/useEditVerificationStore.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+interface IEditVerificationState {
+  isVerified: boolean;
+  setIsVerified: (isVerified: boolean) => void;
+  reset: () => void;
+}
+/**
+ * 비밀번호 재입력 인증 전역상태
+ * - localStorage에서 관리하지 않음.
+ */
+export const useEditVerificationStore = create<IEditVerificationState>(
+  (set) => ({
+    isVerified: false,
+    setIsVerified: (isVerified) => set({ isVerified }),
+    reset: () => set({ isVerified: false }),
+  })
+);

--- a/src/store/useLoginStore.ts
+++ b/src/store/useLoginStore.ts
@@ -5,9 +5,13 @@ import { IUser } from "@/typescript/user.interface";
 interface LoginState {
   isLogin: boolean;
   token: string;
-  userInfo: IUser | null;
-  excuteLogin: (data: IUser) => void;
+  userInfo: ILoginUserInfo | null;
+  excuteLogin: (data: ILoginUserInfo) => void;
   excuteLogout: () => void;
+}
+
+interface ILoginUserInfo extends IUser {
+  provider: null | "google" | "kakao" | "naver";
 }
 
 /** 로그인 전역상태 */

--- a/src/typescript/auth.interface.ts
+++ b/src/typescript/auth.interface.ts
@@ -3,6 +3,7 @@ import { IUser } from "@/typescript/user.interface";
 export interface ISignInResult extends IUser {
   token: string;
   isDeleted: boolean; // 탈퇴 후 재로그인 여부 전달 (25.04.24 새로 isDeleted 추가)
+  provider: null | "google" | "kakao" | "naver";
 }
 
 export interface IKakaoSignInResult {

--- a/src/utils/services/auth/kakao.ts
+++ b/src/utils/services/auth/kakao.ts
@@ -65,7 +65,7 @@ interface IAuthKakaoSignupProps {
 /** 카카오 소셜 회원가입 api 함수 */
 export const authKakaoSignup = async (
   props: IAuthKakaoSignupProps
-): Promise<ICommonReturn<IUser>> => {
+): Promise<ICommonReturn<ISignInResult>> => {
   // props
   const { email, username, image_url, provider_id } = props;
 

--- a/src/utils/services/user.ts
+++ b/src/utils/services/user.ts
@@ -43,7 +43,7 @@ export const signUp = async (
  */
 export const signIn = async (
   props: ISignInFormValues
-): Promise<ICommonReturn<IUser>> => {
+): Promise<ICommonReturn<ISignInResult>> => {
   try {
     // 객체분해할당
     const { email, password } = props;

--- a/src/utils/services/user.ts
+++ b/src/utils/services/user.ts
@@ -1,11 +1,11 @@
 import { ISignInFormValues } from "@/app/login/page";
+import { IVerifyPasswordFormValues } from "@/app/my-page/edit/verify-password/page";
 import { ISignUpFormValues } from "@/app/sign-up/page";
 import { ISignInResult } from "@/typescript/auth.interface";
 import {
   ICommonResponse,
   ICommonReturn,
 } from "@/typescript/common/response.interface";
-import { IUser } from "@/typescript/user.interface";
 import apiClient from "@/utils/axios";
 
 /**
@@ -103,6 +103,33 @@ export const signOut = async (): Promise<ICommonReturn<null>> => {
       result: "success",
       message: "로그아웃 되었습니다.",
     };
+  } catch (error: any) {
+    return {
+      data: null,
+      result: "failure",
+      message: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+/**
+ * 비밀번호 재입력 인증
+ */
+export const vefifyPassword = async (
+  props: IVerifyPasswordFormValues
+): Promise<ICommonReturn<null>> => {
+  try {
+    // 객체분해할당
+    const { password } = props;
+
+    const response: ICommonResponse<null> = await apiClient.post(
+      `${process.env.NEXT_PUBLIC_NESTJS_SERVER}/auth/verify-password`,
+      {
+        password,
+      }
+    );
+
+    return response.data;
   } catch (error: any) {
     return {
       data: null,


### PR DESCRIPTION
### [Update:[auth] 모든 로그인 api - 응답값에 provider 필드 추가 ](https://github.com/changmoolee/joseph-instagram/commit/c404a53df360462afee24586c949ce24a20fe0a3) 
- 로그인 성공시, provider 필드도 로그인 전역상태에 포함
- provider 필드 활용하여 -> 소셜로그인 여부를 판단함


### [Feat:[비밀번호 재인증] 페이지 및 api 추가](https://github.com/changmoolee/joseph-instagram/commit/47773533e3093aa3913af0cfd114167345b4a94c)
- 일반 로그인은 비밀번호 재인증 페이지에서 비밀번호 인증 이후 내정보수정 페이지 접근 가능
- 소셜 로그인은 인증 필요 x

### [Update:[내정보수정] 비밀번호 재입력 인증 전역 상태 활용하여 비인가 접근 차단 조치](https://github.com/changmoolee/joseph-instagram/commit/05f3414635cf71407fb046f6c20a0fbcfbf115da)
### [Feat:[useEditVerificationStore] 비밀번호 재입력 인증 전역상태 추가](https://github.com/changmoolee/joseph-instagram/commit/9f83f79b1fae19741f991fa615c5f9d1da9d062e)
- 내정보수정 페이지는 비밀번호 재인증 페이지를 거쳐야만 접근 가능하도록 수정
- useEditVerificationStore 전역상태를 활용하여 인증여부를 구분지음